### PR TITLE
Update action.lua

### DIFF
--- a/action.lua
+++ b/action.lua
@@ -34,6 +34,7 @@ end
 
 local function charge()
     gps.go(config.chargerPos)
+    gps.turnTo(1)
     repeat
         os.sleep(0.5)
     until fullyCharged()


### PR DESCRIPTION
Forced robot to face initial direction before charging ... this means that when turning off the redstone, we can reset the robot with an unfinished program, !!without!! having to break and replace the robot.