### PR TITLE
Fixed autoSpread parent refill logic

### DIFF
--- a/autoSpread.lua
+++ b/autoSpread.lua
@@ -35,23 +35,19 @@ local function checkChild(slot, crop)
 
         elseif crop.name == targetCrop then
             local stat = crop.gr + crop.ga - crop.re
-            if stat >= config.autoSpreadThreshold then
-
+            if stat >= config.autoStatThreshold and findEmpty() and crop.gr <= config.workingMaxGrowth and crop.re <= config.workingMaxResistance then
                 -- Make sure no parent on the working farm is empty
-                if findEmpty() and crop.gr <= config.workingMaxGrowth and crop.re <= config.workingMaxResistance then
-                    action.transplant(posUtil.workingSlotToPos(slot), posUtil.workingSlotToPos(emptySlot))
-                    action.placeCropStick(2)
-                    database.updateFarm(emptySlot, crop)
-
+                action.transplant(posUtil.workingSlotToPos(slot), posUtil.workingSlotToPos(emptySlot))
+                action.placeCropStick(2)
+                database.updateFarm(emptySlot, crop)
+            elseif stat >= config.autoSpreadThreshold then
                 -- No parent is empty, put in storage
-                else
-                    action.transplant(posUtil.workingSlotToPos(slot), posUtil.storageSlotToPos(database.nextStorageSlot()))
-                    database.addToStorage(crop)
-                    action.placeCropStick(2)
-                end
+                action.transplant(posUtil.workingSlotToPos(slot), posUtil.storageSlotToPos(database.nextStorageSlot()))
+                database.addToStorage(crop)
+                action.placeCropStick(2)
 
-            -- Stats are not high enough
             else
+                -- Stats are not high enough
                 action.deweed()
                 action.placeCropStick()
             end


### PR DESCRIPTION
Currently, if the robot is running autoSpread and some of the parents get destroyed (due to the breeding result of grass or other weed-like crops), the robot would not refill in those parent crops under certain settings. (For the sake of demonstration, let's say I have autoStatThreshold=52 (21+31-0) and autoSpreadThreshold=54 (23+31-0).)

This is because for this part of logic, only crops with stats higher than the autoSpreadThreshold will be accepted, so only 23 31 0 ones, but they are not possibe to have growth stats lower than 21. So autoStatThreshold should be used instead of autoSpreadThreshold for working farm.